### PR TITLE
ログアウト用フォームのショートコードとかの追加

### DIFF
--- a/App/Shortcode/LogoutForm.php
+++ b/App/Shortcode/LogoutForm.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package snow-monkey-member-post
+ * @author inc2734
+ * @license GPL-2.0+
+ */
+
+namespace Snow_Monkey\Plugin\SnowMonkeyMemberPost\App\Shortcode;
+
+use Snow_Monkey\Plugin\SnowMonkeyMemberPost\App\Config;
+use Snow_Monkey\Plugin\SnowMonkeyMemberPost\App\View;
+
+class LogoutForm {
+
+	public function __construct() {
+		add_shortcode( 'snow_monkey_member_post_logout_form', [ $this, '_view' ] );
+	}
+
+	/**
+	 * Register shortcode
+	 *
+	 * @param array $atts
+	 * @return string
+	 * @see https://core.trac.wordpress.org/browser/trunk/src/wp-login.php
+	 */
+	public function _view( $atts ) {
+		if ( ! is_user_logged_in() ) {
+			ob_start();
+			View::render( 'shortcode/logout-form/loggedout' );
+			return ob_get_clean();
+		}
+
+		$atts = shortcode_atts(
+			[
+				'redirect_to' => $this->_get_current_url(),
+			],
+			$atts
+		);
+
+		ob_start();
+		View::render( 'shortcode/logout-form/index', $atts );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Return current URL
+	 *
+	 * @return string
+	 */
+	protected function _get_current_url() {
+		$path = filter_input( INPUT_SERVER, 'REQUEST_URI' );
+		$path = remove_query_arg( 'login_error_codes', $path );
+		$path = remove_query_arg( 'register_error_codes', $path );
+		return home_url( $path );
+	}
+}

--- a/snow-monkey-member-post.php
+++ b/snow-monkey-member-post.php
@@ -36,6 +36,7 @@ class Bootstrap {
 		new App\Controller\Excerpt();
 
 		new App\Shortcode\LoginForm();
+		new App\Shortcode\LogoutForm();
 		new App\Shortcode\RegisterForm();
 	}
 

--- a/templates/shortcode/logout-form/index.php
+++ b/templates/shortcode/logout-form/index.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package snow-monkey-member-post
+ * @author inc2734
+ * @license GPL-2.0+
+ */
+
+use Snow_Monkey\Plugin\SnowMonkeyMemberPost\App\Config;
+use Snow_Monkey\Plugin\SnowMonkeyMemberPost\App\View;
+
+?>
+<div class="c-row c-row--margin-s">
+	<div class="c-row__col c-row__col--1-1">
+		<?php esc_attr_e( 'Are you attempting to log out?', 'snow-monkey-member-post' ); ?>
+	</div>
+	<div class="c-row__col c-row__col--1-1">
+		<a href="<?php echo wp_logout_url( $redirect_to ); ?>" class="button logout-link"><?php esc_html_e( 'Log out', 'snow-monkey-member-post' ); ?></a>
+	</div>
+</div>

--- a/templates/shortcode/logout-form/loggedout.php
+++ b/templates/shortcode/logout-form/loggedout.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package snow-monkey-member-post
+ * @author inc2734
+ * @license GPL-2.0+
+ */
+?>
+
+<div class="wpac-alert wpac-alert--success">
+	<?php esc_html_e( 'You are logged out.', 'snow-monkey-member-post' ); ?>
+</div>


### PR DESCRIPTION
ちょっと作ってるサイトでログアウトリンクとか設定する必要があったので…一応プルリクしときますー。
ログアウトもやりたいけどやり方解らん人とか、誰かが使うかも解らんのでー。

単純にログアウトリンク入れてるだけな適当です…すみません。
ログアウト出来なかった時はWP標準のエラーページ出ます。そこはどうしようも出来ないっぽいです。

パスワードを忘れた際のLostPasswordFormは、多分近々…（作る必要ある為、途中まで制作している最中…）

---

ローカライズは、diffがおかしくなるのでpo入れてません。
下記の３つを追加してください。

Are you attempting to log out? ＞ ログアウトしますか？
Log out ＞ ログアウト
You are logged out. ＞ ログアウトしています

って感じです。