### PR TITLE
ログアウトとの分岐対応、redirect_toが設定されている場合、正しくエラーが出ない問題の断定対応

### DIFF
--- a/App/Shortcode/LoginForm.php
+++ b/App/Shortcode/LoginForm.php
@@ -25,21 +25,19 @@ class LoginForm {
 	 * @see https://core.trac.wordpress.org/browser/trunk/src/wp-login.php
 	 */
 	public function _view( $atts ) {
-		if ( is_user_logged_in() ) {
-			ob_start();
-			View::render( 'shortcode/login-form/loggedin' );
-			return ob_get_clean();
-		}
-
 		$atts = shortcode_atts(
 			[
 				'redirect_to' => $this->_get_current_url(),
+				'current_url' => $this->_get_current_url(),
 			],
 			$atts
 		);
 
 		ob_start();
-		View::render( 'shortcode/login-form/index', $atts );
+		View::render(
+			is_user_logged_in() ? 'shortcode/login-form/loggedin' : 'shortcode/login-form/index',
+			$atts
+		);
 		return ob_get_clean();
 	}
 
@@ -67,14 +65,21 @@ class LoginForm {
 		}
 
 		$redirect_to = filter_input( INPUT_POST, 'redirect_to' );
-		if ( ! $redirect_to ) {
+		$current_url = filter_input( INPUT_POST, 'current_url' );
+		if ( ! $redirect_to || ! $current_url ) {
 			return $user;
 		}
 
 		$error_codes = implode( ',', $user->get_error_codes() );
 		$redirect_to = add_query_arg( 'login_error_codes', $error_codes, $redirect_to );
 
-		wp_safe_redirect( $redirect_to );
+		if ( empty( $error_codes ) ) {
+			wp_safe_redirect( $redirect_to );
+		} else {
+			$current_url = remove_query_arg( 'login_error_codes', $current_url );
+			$current_url = add_query_arg( 'login_error_codes', $error_codes, $current_url );
+			wp_safe_redirect( $current_url );
+		}
 	}
 
 	/**

--- a/templates/shortcode/login-form/index.php
+++ b/templates/shortcode/login-form/index.php
@@ -38,6 +38,7 @@ if ( filter_input( INPUT_GET, 'login_error_codes' ) && explode( ',', $login ) ) 
 				<?php esc_attr_e( 'Log In', 'snow-monkey-member-post' ); ?>
 			</button>
 			<input type="hidden" name="redirect_to" value="<?php echo esc_attr( $redirect_to ); ?>">
+			<input type="hidden" name="current_url" value="<?php echo esc_attr( $current_url ); ?>">
 		</div>
 		<div class="c-row__col c-row__col--1-1">
 			<ul class="smmp-login-form__nav">
@@ -62,3 +63,4 @@ if ( filter_input( INPUT_GET, 'login_error_codes' ) && explode( ',', $login ) ) 
 	?>
 	<input type="hidden" name="<?php echo esc_attr( $nonce_key ); ?>" value="<?php echo esc_attr( $nonce ); ?>">
 </form>
+

--- a/templates/shortcode/login-form/loggedin.php
+++ b/templates/shortcode/login-form/loggedin.php
@@ -6,6 +6,11 @@
  */
 ?>
 
-<div class="wpac-alert wpac-alert--success">
-	<?php esc_html_e( 'You are logged in.', 'snow-monkey-member-post' ); ?>
+<div class="c-row c-row--margin-s">
+	<div class="c-row__col c-row__col--1-1">
+		<?php esc_attr_e( 'Are you attempting to log out?', 'snow-monkey-member-post' ); ?>
+	</div>
+	<div class="c-row__col c-row__col--1-1">
+		<a href="<?php echo wp_logout_url( $redirect_to ); ?>" class="button logout-link"><?php esc_html_e( 'Log out', 'snow-monkey-member-post' ); ?></a>
+	</div>
 </div>


### PR DESCRIPTION
とりあえずログアウトとの分岐にしました。

んで…redirect_toが別ページに設定されている場合にログインエラーが起こった時はリダイレクト先に飛んでしまうので正しくエラーが出ない問題がありました。一応の仮対応を入れといてます。
current_urlみたいな感じで追加したんですが、何かいい感じに調整してください。

registでもエラー時のリダイレクト問題は起こるので、そっちもいい感じに調整お願いしますー。
regist側は手をつけていないです。